### PR TITLE
Pad-1: fixed ngraph reference for symmetric mode and added cpu tests

### DIFF
--- a/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/single_layer_tests/pad.cpp
+++ b/inference-engine/tests/functional/plugin/cpu/shared_tests_instances/single_layer_tests/pad.cpp
@@ -21,6 +21,7 @@ const std::vector<float> argPadValue = {0.f, 1.f, 2.f, -1.f};
 const std::vector<ngraph::helpers::PadMode> padMode = {
         ngraph::helpers::PadMode::EDGE,
         ngraph::helpers::PadMode::REFLECT,
+        ngraph::helpers::PadMode::SYMMETRIC
 };
 
 const auto pad2DConstparams = testing::Combine(

--- a/ngraph/core/reference/src/runtime/reference/pad.cpp
+++ b/ngraph/core/reference/src/runtime/reference/pad.cpp
@@ -191,8 +191,8 @@ namespace ngraph
                                 }
                                 else
                                 {
-                                    c[i] = static_cast<size_t>(padding_below[i] + src_dim +
-                                                               padding_above[i] - pos);
+                                    c[i] = static_cast<size_t>(2 * (padding_below[i] + src_dim) -
+                                                               c[i] - 1);
                                 }
                             }
                         }


### PR DESCRIPTION
Ngraph reference did not correspond to pad-1 specification for symmetric mode. This PR fixes it.